### PR TITLE
Remove 3D Force Graph thumbnail

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Documentation: https://omniscope.me/_global_/customview/v1/docs/
         <td width="33%">Running Pivot View<br><a href="runningpivot" title="Running Pivot View"><img width="290" src="https://github.com/visokio/custom-views/raw/master/runningpivot/thumbnail.png"></a></td>
         <td width="33%">Custom View Demo<br><a href="customviewdemo" title="Custom View Demo"><img width="290" src="https://github.com/visokio/custom-views/raw/master/customviewdemo/thumbnail.png"></a></td>
     </tr>
+    <tr valign="top">
+        <td width="33%"><a href="threeforcegraph" title="3D Force Graph">3D Force Graph</a></td>
+        <td width="33%"></td>
+        <td width="33%"></td>
+    </tr>
 </table>
 
 ### How to create a new view

--- a/threeforcegraph/README.md
+++ b/threeforcegraph/README.md
@@ -1,0 +1,18 @@
+# ![](icon.svg) 3D Force Graph
+
+Custom view that renders a 3D force-directed graph using the [3d-force-graph](https://github.com/vasturiano/3d-force-graph) library.
+
+## Use case
+
+Visualise network relationships in 3D using Three.js force layout.
+
+## Settings
+
+ - **Source**: Field representing the link source node.
+ - **Target**: Field representing the link target node.
+ - **Group (optional)**: Categorical field used to colour nodes.
+
+
+## Libraries
+ - [3d-force-graph](https://github.com/vasturiano/3d-force-graph)
+ - [Three.js](https://threejs.org/)

--- a/threeforcegraph/icon.svg
+++ b/threeforcegraph/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" stroke="black" stroke-width="2" fill="none"/>
+  <line x1="16" y1="2" x2="16" y2="30" stroke="black" stroke-width="2"/>
+  <line x1="2" y1="16" x2="30" y2="16" stroke="black" stroke-width="2"/>
+</svg>

--- a/threeforcegraph/index.html
+++ b/threeforcegraph/index.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <style>
+        html, body, main {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+        }
+        #main {
+            width: 100%;
+            height: 100%;
+            position: absolute;
+            overflow: hidden;
+        }
+    </style>
+    <script src="https://unpkg.com/3d-force-graph"></script>
+</head>
+<body>
+<main id="main"></main>
+<script src="/_global_/customview/v1/omniscope.js"></script>
+<script>
+    if (!omniscope || !omniscope.view) throw new Error("Omniscope chart API is not loaded");
+
+    omniscope.view.on("load", function() {
+        window.onerror = function(msg) {
+            omniscope.view.error(msg);
+        }
+    });
+
+    omniscope.view.on(["load", "update", "resize"], function() {
+        const context = omniscope.view.context();
+        const records = context.result.data.records;
+        const mappings = context.result.mappings;
+
+        const sourceIdx = mappings.source;
+        const targetIdx = mappings.target;
+        const groupIdx = mappings.group;
+
+        const nodesMap = new Map();
+        const links = [];
+
+        records.forEach(record => {
+            const src = record[sourceIdx];
+            const tgt = record[targetIdx];
+            if (src == null || tgt == null) return;
+            if (!nodesMap.has(src)) nodesMap.set(src, { id: src, group: groupIdx !== undefined ? record[groupIdx] : null });
+            if (!nodesMap.has(tgt)) nodesMap.set(tgt, { id: tgt, group: groupIdx !== undefined ? record[groupIdx] : null });
+            links.push({ source: src, target: tgt });
+        });
+
+        const nodes = Array.from(nodesMap.values());
+
+        document.getElementById('main').innerHTML = '';
+
+        const Graph = ForceGraph3D()(document.getElementById('main'))
+            .graphData({ nodes: nodes, links: links })
+            .nodeAutoColorBy('group');
+    });
+</script>
+</body>
+</html>

--- a/threeforcegraph/manifest.json
+++ b/threeforcegraph/manifest.json
@@ -1,0 +1,69 @@
+{
+  "name": "3D Force Graph",
+  "frameworkVersion": "v1",
+  "icon": "icon.svg",
+  "tags": ["custom", "3d", "graph", "network", "three.js"],
+  "sandbox": false,
+  "autoPane": true,
+  "autoQuery": true,
+  "dataLimit": 10000,
+  "supportsSelection": false,
+  "options": {
+    "items": {
+      "source": {
+        "displayName": "Source",
+        "type": "GROUPING",
+        "mandatory": true
+      },
+      "target": {
+        "displayName": "Target",
+        "type": "GROUPING",
+        "mandatory": true
+      },
+      "group": {
+        "displayName": "Group",
+        "type": "GROUPING",
+        "list": false
+      },
+      "paneX": {
+        "displayName": "Pane X",
+        "type": "GROUPING",
+        "list": true
+      },
+      "paneY": {
+        "displayName": "Pane Y",
+        "type": "GROUPING",
+        "list": true
+      }
+    },
+    "structure": {
+      "toolbar": ["source", "target"],
+      "x": ["paneX"],
+      "y": ["paneY"]
+    }
+  },
+  "defaultOptions": {
+    "items": {},
+    "pane": {
+      "yAxisHeaderWidth": 75,
+      "paneWidth": 200,
+      "paneHeight": 200,
+      "gridLineThickness": 1,
+      "gridLineColour": "rgba(229,229,229,1)",
+      "headerStyle": {
+        "size": 12,
+        "colour": "#333333",
+        "backgroundColour": "#FFFFFF"
+      },
+      "tileHeaderAlignment": "CENTER",
+      "xHeaderPlacement": "TOP",
+      "yHeaderPlacement": "LEFT",
+      "showColourKeyInEveryPane": false,
+      "enableTouchScrolling": false
+    }
+  },
+  "pane": {
+    "minWidth": 50,
+    "minHeight": 50
+  }
+}

--- a/views.json
+++ b/views.json
@@ -262,5 +262,12 @@
 			"files": [],
 			"version": 0
 		}
+                ,{
+                        "name": "threeforcegraph",
+                        "displayName": "3D Force Graph",
+                        "tags": ["custom", "3d", "graph", "network", "three.js"],
+                        "files": [],
+                        "version": 0
+                }
 	]
 }


### PR DESCRIPTION
## Summary
- drop `thumbnail.png` from 3D Force Graph view
- trim thumbnail setting from its manifest
- remove screenshot from 3D Force Graph README
- show view name as a text link in the gallery

## Testing
- `pytest -q`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f4a8a85b883339157fc83b5bd2426